### PR TITLE
Enhancement language picker

### DIFF
--- a/src/components/language-picker/LanguagePicker.jsx
+++ b/src/components/language-picker/LanguagePicker.jsx
@@ -30,8 +30,8 @@ const LANGUAGE = [
     name: "English",
   },
   {
-    key: "en-gb",
-    flag: "gb",
+    key: "",
+    flag: "",
     name: "*",
   },
   {

--- a/src/components/language-picker/LanguagePicker.jsx
+++ b/src/components/language-picker/LanguagePicker.jsx
@@ -1,4 +1,4 @@
-import { Box, MenuItem, Select, makeStyles } from "@material-ui/core";
+import { Box, MenuItem, Select, makeStyles, Divider } from "@material-ui/core";
 import React from "react";
 import { useTranslation } from "react-i18next";
 
@@ -28,11 +28,6 @@ const LANGUAGE = [
     key: "en-gb",
     flag: "gb",
     name: "English",
-  },
-  {
-    key: "",
-    flag: "",
-    name: "*",
   },
   {
     key: "ar",
@@ -144,12 +139,9 @@ export const LanguageSelector = () => {
         },
         getContentAnchorEl: null,
       }}>
-      {LANGUAGE.map((option) => (option.name !== "*" ? 
-        <MenuItem key={option.key} value={option.key} name={option.name} flag={option.flag}>
+      {LANGUAGE.map((option) => (
+        <MenuItem key={option.key} value={option.key} name={option.name} flag={option.flag} divider={option.key === 'en-gb' && true}>
           <FlagIcon countryCode={LANGUAGE.find((item) => item.key === option.key)?.flag} />
-          <div className={classes.textBox}>{option.name}</div>
-        </MenuItem> :
-        <MenuItem disabled>
           <div className={classes.textBox}>{option.name}</div>
         </MenuItem>
       ))}

--- a/src/components/language-picker/LanguagePicker.jsx
+++ b/src/components/language-picker/LanguagePicker.jsx
@@ -30,9 +30,19 @@ const LANGUAGE = [
     name: "English",
   },
   {
+    key: "en-gb",
+    flag: "gb",
+    name: "*",
+  },
+  {
     key: "ar",
     flag: "sa",
     name: "العربية",
+  },
+  {
+    key: "zh-SC",
+    flag: "cn",
+    name: "简体",
   },
   {
     key: "zh-HK",
@@ -40,9 +50,9 @@ const LANGUAGE = [
     name: "繁體",
   },
   {
-    key: "zh-SC",
-    flag: "cn",
-    name: "简体",
+    key: "zh-TW",
+    flag: "tw",
+    name: "繁體",
   },
   {
     key: "es",
@@ -134,9 +144,12 @@ export const LanguageSelector = () => {
         },
         getContentAnchorEl: null,
       }}>
-      {LANGUAGE.map((option) => (
+      {LANGUAGE.map((option) => (option.name !== "*" ? 
         <MenuItem key={option.key} value={option.key} name={option.name} flag={option.flag}>
           <FlagIcon countryCode={LANGUAGE.find((item) => item.key === option.key)?.flag} />
+          <div className={classes.textBox}>{option.name}</div>
+        </MenuItem> :
+        <MenuItem disabled>
           <div className={classes.textBox}>{option.name}</div>
         </MenuItem>
       ))}


### PR DESCRIPTION
## Introduction ##
The merge request reflecting the enhancement requested by Howie in following:
1. Languages sequence & flags
2. Separator update

**Note: The separator can be applied in a disabled `MenuItem` separately; as of now, as it does not contain any functional change, i suggest to keep it as the minimal change, i.e.: using the `<Divider/>` instead of applying a disalbed menuitem for now**

Following sequence changes:
```
English

* (or a line - to show English is the reference)

Arabic العربية

(PRC flag) 简体

(Hong Kong flag) 繁體

(ROC flag) 繁體
.....
```

Screenshot: 
![image](https://github.com/anthony-poon/react.website-toolkits/assets/67136646/2d5393d6-27f2-49e8-a317-685c04d7cc5a)



Separator in disabled menuitem (Not in this MR, but for referencing)
![image](https://github.com/anthony-poon/react.website-toolkits/assets/67136646/a26a28d5-0072-4432-846a-5cb32559a1cf)
 