### PR TITLE
Add per-column disableTooltip flag to DefaultCRUDTable

### DIFF
--- a/src/apps/crud/table/DefaultCRUDTable.jsx
+++ b/src/apps/crud/table/DefaultCRUDTable.jsx
@@ -94,16 +94,20 @@ const getColDef = (props) => {
       headerName: prop.label,
       sortable: prop.sortable,
       disableColumnMenu: prop.disableColumnMenu,
-      renderCell: ({ value }) =>
-        prop.disableTooltip ? (
-          <Component value={value} />
+      renderCell: ({ value }) => {
+        const cell = (
+          <Box sx={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            <Component value={value} />
+          </Box>
+        );
+        return prop.disableTooltip ? (
+          cell
         ) : (
           <Tooltip title={value != null ? <Component value={value} /> : ""} disableInteractive enterDelay={500}>
-            <Box sx={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-              <Component value={value} />
-            </Box>
+            {cell}
           </Tooltip>
-        ),
+        );
+      },
       width: prop.size === "flex" ? undefined : WIDTH_MAPPING[prop.size] || 50,
       flex: prop.size === "flex" ? 1 : undefined,
       minWidth: 50,

--- a/src/apps/crud/table/DefaultCRUDTable.jsx
+++ b/src/apps/crud/table/DefaultCRUDTable.jsx
@@ -94,13 +94,16 @@ const getColDef = (props) => {
       headerName: prop.label,
       sortable: prop.sortable,
       disableColumnMenu: prop.disableColumnMenu,
-      renderCell: ({ value }) => (
-        <Tooltip title={value != null ? <Component value={value} /> : ""} disableInteractive enterDelay={500}>
-          <Box sx={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-            <Component value={value} />
-          </Box>
-        </Tooltip>
-      ),
+      renderCell: ({ value }) =>
+        prop.disableTooltip ? (
+          <Component value={value} />
+        ) : (
+          <Tooltip title={value != null ? <Component value={value} /> : ""} disableInteractive enterDelay={500}>
+            <Box sx={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+              <Component value={value} />
+            </Box>
+          </Tooltip>
+        ),
       width: prop.size === "flex" ? undefined : WIDTH_MAPPING[prop.size] || 50,
       flex: prop.size === "flex" ? 1 : undefined,
       minWidth: 50,
@@ -359,6 +362,7 @@ DefaultCRUDTable.propTypes = {
       key: PropTypes.string.isRequired,
       sortable: PropTypes.bool,
       component: PropTypes.elementType,
+      disableTooltip: PropTypes.bool,
     }),
   ).isRequired,
   countPerPage: PropTypes.number,


### PR DESCRIPTION
[Feature] Adds a `disableTooltip` schema flag on `DefaultCRUDTable` so columns can opt out of the auto-tooltip while keeping ellipsis truncation.